### PR TITLE
fix(orm): Fix ArchiveFileCopyRequest primary key

### DIFF
--- a/chimedb/data_index/orm.py
+++ b/chimedb/data_index/orm.py
@@ -678,6 +678,3 @@ class ArchiveFileCopyRequest(base_model):
     timestamp = pw.DateTimeField()
     transfer_started = pw.DateTimeField(null=True)
     transfer_completed = pw.DateTimeField(null=True)
-
-    class Meta(object):
-        primary_key = pw.CompositeKey("file", "group_to", "node_from")


### PR DESCRIPTION
This table now has a auto-incremented `id` primary key. This weird primary key override is no longer applicable.

(Keeping this in makes `peewee` ignore the `id` column: all records retrieved have `ArchiveFileCopyRequest.id=None`.)