### PR TITLE
feat: Add StorageTransferAction table and data

### DIFF
--- a/chimedb/data_index/orm.py
+++ b/chimedb/data_index/orm.py
@@ -1025,6 +1025,63 @@ class StorageNode(base_model):
     io_config = pw.TextField(null=True)
 
 
+class StorageTransferAction(base_model):
+    """Storage transfer rules for the archive.
+
+    This provides configuration for the edges in the storage node/group directed
+    graph.
+
+    Attributes
+    ----------
+    node_from : foreign key
+        The source node for the transfer.
+    group_to : foreign key
+        The destination group for the transfer.
+    autosync : boolean
+        If True, automatically copy files from `node_from` to `group_to`.
+    autoclean : boolean
+        If True, automatically delete file copies from `node_from` after they
+        end up in `group_to`.
+
+    Notes
+    -----
+    If `NODE_A` is in `GROUP_A` and `NODE_B` in `GROUP_B`, then
+    `StorageTransferAction(node_from=NODE_A, group_to=NODE_B)` and
+    `StorageTransferAction(node_from=NODE_B, group_to=NODE_A)` are distinct.
+    (i.e. all edges are directed).
+
+    Alpenhorn ignores records where `group_to == node_from.group` (self-loops).
+
+    Autosyncing:
+        If `autosync` between a NODE and a GROUP is enabled, then whenever a
+        new file copy is added to NODE (i.e. after a successful import or pull),
+        then a new `ArchiveFileCopyRequest` will be created to transfer the file
+        from NODE to GROUP, so long as the file doesn't already exist in GROUP.
+
+    Autocleaning:
+        If `autoclean` between a NODE and a GROUP is enabled, then whenever a
+        new file copy is added to GROUP (i.e. after a successful import or pull,
+        regardless of the origin of the file), then the file will be scheduled
+        for deletion from NODE (by setting `ArchiveFileCopy.wants_file` to "N"
+        for the file copy on NONE).
+    """
+
+    node_from = pw.ForeignKeyField(StorageNode, backref="transfers_from")
+    group_to = pw.ForeignKeyField(StorageGroup, backref="transfers_to")
+    autosync = pw.BooleanField(default=False)
+    autoclean = pw.BooleanField(default=False)
+
+    @property
+    def self_loop(self) -> bool:
+        """True if this is a self-loop (i.e. node_from.group == group_to)."""
+        return self.node_from.group == self.group_to
+
+    class Meta:
+        indexes = (
+            (("node_from", "group_to"), True),
+        )  # (node_from, group_to) is unique
+
+
 class ArchiveFileCopy(base_model):
     """Information about a file.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,9 @@ from chimedb.data_index.orm import (
     AcqType,
     ArchiveInst,
     FileType,
+    StorageNode,
+    StorageGroup,
+    StorageTransferAction,
 )
 
 
@@ -34,5 +37,8 @@ def tables(proxy):
             AcqType,
             ArchiveInst,
             FileType,
+            StorageNode,
+            StorageGroup,
+            StorageTransferAction,
         ]
     )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,14 @@
 """Test util."""
 
 from chimedb.data_index import util
-from chimedb.data_index.orm import AcqType, FileType, AcqFileTypes
+from chimedb.data_index.orm import (
+    AcqType,
+    FileType,
+    AcqFileTypes,
+    StorageGroup,
+    StorageNode,
+    StorageTransferAction,
+)
 
 
 def test_update_types(tables):
@@ -40,3 +47,57 @@ def test_update_types(tables):
         fts = list(AcqFileTypes.select().where(AcqFileTypes.acq_type == at))
         assert len(fts) == 1
         assert fts[0].file_type == ft
+
+
+def test_update_storage(tables):
+    """Test update_storage()."""
+
+    # Create the storage data
+    util.update_storage()
+
+    # Check
+    for group in [
+        "scinet_staging",
+        "scinet_hpss",
+        "drao_storage",
+        "cedar_offload",
+        "cedar_online",
+        "cedar_staging",
+        "cedar_nearline",
+    ]:
+        StorageGroup.get(name=group)
+
+    for node in [
+        "gong",
+        "cedar_offload",
+        "cedar_staging",
+        "cedar_smallfile",
+        "cedar_nearline",
+        "cedar_online",
+        "scinet_staging",
+        "scinet_hpss",
+    ]:
+        StorageNode.get(name=node)
+
+    edges = [
+        ("gong", "cedar_staging", True, False),
+        ("cedar_staging", "cedar_offload", True, False),
+        ("cedar_staging", "scinet_staging", True, False),
+        ("cedar_staging", "scinet_hpss", False, True),
+        ("cedar_offload", "cedar_nearline", True, True),
+        ("scinet_staging", "scinet_hpss", True, True),
+    ]
+
+    for edge in edges:
+        sta = (
+            StorageTransferAction.select()
+            .join(StorageGroup)
+            .switch(StorageTransferAction)
+            .join(StorageNode)
+            .select()
+            .where(StorageNode.name == edge[0], StorageGroup.name == edge[1])
+            .get()
+        )
+
+        assert sta.autosync == edge[2]
+        assert sta.autoclean == edge[3]


### PR DESCRIPTION
Backport of the new table from https://github.com/radiocosmology/alpenhorn/pull/170 mostly so I have some place to record what the contents of the table should be (in `util.py:update_storage`).