### PR TITLE
Fix typo in 'build-backend' and increase min python to 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning"]
-build-backed = "setuptools.build_meta"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimedb.data_index"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   {name = "D. V. Wiebe for the CHIME Collaboration", email = "dvw@phas.ubc.ca"}
 ]
 description = "CHIME data index (alpenhorn) ORM"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["readme", "version"]
 license = {file = "LICENSE"}
 dependencies = [


### PR DESCRIPTION
Failing tests are because `chimedb` requires python >= 3.9, but `chimedb-di` is trying to run tests on 3.8. I guess we should just increase the minimum python for all the `chimedb` modules to 3.9