### PR TITLE
refactor: Update for alpenhorn data index changes

### DIFF
--- a/chimedb/data_index/orm.py
+++ b/chimedb/data_index/orm.py
@@ -1001,6 +1001,27 @@ class StorageGroup(base_model):
     io_config = pw.TextField(null=True)
 
 
+class StorageHost(base_model):
+    """Storage host for the archive.
+
+    Attributes
+    ----------
+    name : string
+        The name of this host.
+    username : string
+        The log-in username for remote access to this host
+    address : string
+        The internet address for the host (e.g., archive.example.com)
+    notes : string
+        Notes about this host
+    """
+
+    name = pw.CharField(max_length=64, unique=True)
+    username = pw.CharField(max_length=64, null=True)
+    address = pw.CharField(max_length=255, null=True)
+    notes = pw.TextField(null=True)
+
+
 class StorageNode(base_model):
     """A path on a disc where archives are stored.
 
@@ -1012,21 +1033,16 @@ class StorageNode(base_model):
         The root directory for data in this node.
     host : string
         The hostname that this node lives on.
-    address : string
-        The internet address for the host (e.g., mistaya.phas.ubc.ca)
+    io_class : string
+        The I/O class for this node.
     group : foreign key
         The group to which this node belongs.
     active : bool
         Is the node active?
     auto_import : bool
         Should files that appear on this node be automatically added?
-    suspect : bool
-        Deprecated
-    storage_type : enum
-        What is the type of storage?
-        - 'A': archive for the data
-        - 'T': for transiting data
-        - 'F': for data in the field (i.e acquisition machines)
+    archive : bool
+        Is this an archive node?
     max_total_gb : float
         The maximum amout of storage we should use.
     min_avail_gb : float
@@ -1035,30 +1051,25 @@ class StorageNode(base_model):
         How much free space is there on this node?
     avail_gb_last_checked : datetime
         When was the amount of free space last checked?
-    min_delete_age_days : float
-        What is the minimum amount of time a file must remain on the node before
-        we are allowed to delete it?
     notes : string
         Any notes or comments about this node.
+    io_config : string
+        The I/O config used by the I/O class.
     """
 
     name = pw.CharField(max_length=64, unique=True)
     root = pw.CharField(max_length=255, null=True)
-    host = pw.CharField(max_length=64, null=True)
-    username = pw.CharField(max_length=64, null=True)
-    address = pw.CharField(max_length=255, null=True)
+    host = pw.ForeignKeyField(StorageHost, backref="nodes", null=True)
     io_class = pw.CharField(max_length=255, null=True)
     group = pw.ForeignKeyField(StorageGroup, backref="nodes")
     active = pw.BooleanField(default=False)
     auto_import = pw.BooleanField(default=False)
     auto_verify = pw.IntegerField(default=0)
-    suspect = pw.BooleanField(default=False, null=True)
-    storage_type = EnumField(["A", "T", "F"], default="A")
+    archive = pw.BooleanField(default=False)
     max_total_gb = pw.FloatField(null=True)
     min_avail_gb = pw.FloatField(default=0)
     avail_gb = pw.FloatField(null=True)
     avail_gb_last_checked = pw.DateTimeField(null=True)
-    min_delete_age_days = pw.FloatField(default=30, null=True)
     notes = pw.TextField(null=True)
     io_config = pw.TextField(null=True)
 

--- a/chimedb/data_index/util.py
+++ b/chimedb/data_index/util.py
@@ -23,6 +23,7 @@ from .orm import (
     ArchiveInst,
     FileType,
     StorageNode,
+    StorageHost,
     StorageGroup,
     StorageTransferAction,
 )
@@ -510,9 +511,51 @@ def update_storage():
     This sets up the standard CHIME dataflow.
     """
 
-    # node and group caches
+    # object dicts used for foreign-key look-ups
     node_dict = dict()
     group_dict = dict()
+    host_dict = dict()
+
+    def _host(id_, name, address, username, notes):
+        """Creates a dict for a host."""
+        return {
+            "id": id_,
+            "name": name,
+            "address": address,
+            "username": username,
+            "notes": notes,
+        }
+
+    hosts = [
+        _host(
+            1,
+            "drao",
+            "hac1-nren.chimenet.ca",
+            "chimeadmin",
+            "At the CHIME telescope.  Data is stored on gong, but the daemon runs on wind.",
+        ),
+        _host(
+            2,
+            "fir",
+            "robot.fir.alliancecan.ca",
+            "chimedat",
+            "WestGrid compute cluster.",
+        ),
+        _host(
+            3,
+            "scinet",
+            "robot3.scinet.utoronto.ca",
+            "chimedat",
+            "SciNet compute cluster.  Access via trillium.",
+        ),
+    ]
+
+    # Create hosts, if necessary
+    for host in hosts:
+        try:
+            host_dict[host["name"]] = StorageHost.get(id=host["id"])
+        except StorageHost.DoesNotExist:
+            host_dict[host["name"]] = StorageHost.create(**host)
 
     def _group(id_, name, io_class, notes):
         """Creates a dict for a group."""
@@ -524,14 +567,9 @@ def update_storage():
         ),
         _group(5, "scinet_hpss", None, "HPSS archival storage at SciNet."),
         _group(7, "drao_storage", None, "Current storage on gong."),
-        _group(
-            9, "cedar_offload", None, "Queue of files waiting to be moved to nearline"
-        ),
-        _group(14, "cedar_online", None, "Archive for active data analysis on cedar."),
-        _group(
-            15, "cedar_staging", None, "Temporary storage for incoming data on cedar."
-        ),
-        _group(16, "cedar_nearline", "LustreHSM", "Nearline archival storage at cedar"),
+        _group(14, "fir_online", None, "Archive for active data analysis on fir."),
+        _group(15, "fir_staging", None, "Temporary storage for incoming data on fir."),
+        _group(16, "fir_nearline", "LustreHSM", "Nearline archival storage at fir."),
     ]
 
     # Create groups, if necessary
@@ -545,9 +583,10 @@ def update_storage():
         id_,
         name,
         group,
+        host=None,
         io_class=None,
         auto_import=False,
-        storage_type="F",
+        archive=False,
         notes=None,
         io_config=None,
     ):
@@ -557,9 +596,10 @@ def update_storage():
             "name": name,
             "io_class": io_class,
             "group": group_dict[group],
+            "host": host_dict.get(host, None),
             "active": False,
+            "archive": archive,
             "auto_import": auto_import,
-            "storage_type": storage_type,
             "notes": notes,
             "io_config": io_config,
         }
@@ -569,40 +609,50 @@ def update_storage():
             11,
             "gong",
             "drao_storage",
+            host="drao",
             io_class="Polling",
             auto_import=True,
-            storage_type="A",
+            archive=True,
         ),
-        _node(1117, "cedar_offload", "cedar_offload", storage_type="A"),
         _node(
             1119,
             "scinet_hpss",
             "scinet_hpss",
-            storage_type="A",
+            host="scinet",
+            archive=True,
             notes="HPSS tape storage node at SciNet.",
         ),
-        _node(1133, "scinet_staging", "scinet_staging", notes="Staging on Niagara"),
+        _node(
+            1133,
+            "scinet_staging",
+            "scinet_staging",
+            host="scinet",
+            notes="Staging on SciNet",
+        ),
         _node(
             1136,
-            "cedar_online",
-            "cedar_online",
+            "fir_online",
+            "fir_online",
+            host="fir",
             io_class="LustreQuota",
             io_config='{"quota_group": "rpp-chime"}',
         ),
-        _node(1137, "cedar_staging", "cedar_staging"),
+        _node(1137, "fir_staging", "fir_staging", host="fir"),
         _node(
             1139,
-            "cedar_nearline",
-            "cedar_nearline",
+            "fir_nearline",
+            "fir_nearline",
             io_class="LustreHSM",
-            storage_type="A",
+            host="fir",
+            archive=True,
             io_config='{"quota_group": "rpp-chime", "fixed_quota": 300000000000, "headroom": 25000000000, "release_check_count": 100}',
         ),
         _node(
             1142,
-            "cedar_smallfile",
-            "cedar_nearline",
-            storage_type="A",
+            "fir_smallfile",
+            "fir_nearline",
+            host="fir",
+            archive=True,
             notes="Archival storage for files too small for nearline",
         ),
     ]
@@ -619,17 +669,13 @@ def update_storage():
         return (node_dict[node_from], group_dict[group_to], autosync, autoclean)
 
     actions = [
-        # files appearing on gong are automatically transferred to cedar_staging
-        _action("gong", "cedar_staging", True, False),
-        # files arriving on cedar_staging are automatically transferred to cedar_offload
-        _action("cedar_staging", "cedar_offload", True, False),
-        # files arriving on cedar_staging are automatically transferred to scinet_staging
-        _action("cedar_staging", "scinet_staging", True, False),
-        # files are deleted from cedar_staging after being archived in HPSS on scinet
-        _action("cedar_staging", "scinet_hpss", False, True),
-        # files arriving on cedar_offload are automatically transferred to nearline,
+        # files appearing on gong are automatically transferred to fir_staging
+        _action("gong", "fir_staging", True, False),
+        # files arriving on fir_staging are automatically transferred to nearline,
         # and then deleted once they're in nearline
-        _action("cedar_offload", "cedar_nearline", True, True),
+        _action("fir_staging", "fir_nearline", True, True),
+        # files arriving on fir_nearline are automatically transferred to scinet_staging
+        _action("fir_nearline", "scinet_staging", True, False),
         # files arriving on scinet_staging are automatically transferred to HPSS,
         # and then deleted once they're in HPSS
         _action("scinet_staging", "scinet_hpss", True, True),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ from chimedb.data_index.orm import (
     FileType,
     StorageNode,
     StorageGroup,
+    StorageHost,
     StorageTransferAction,
 )
 
@@ -39,6 +40,7 @@ def tables(proxy):
             FileType,
             StorageNode,
             StorageGroup,
+            StorageHost,
             StorageTransferAction,
         ]
     )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -5,6 +5,7 @@ from chimedb.data_index.orm import (
     AcqType,
     FileType,
     AcqFileTypes,
+    StorageHost,
     StorageGroup,
     StorageNode,
     StorageTransferAction,
@@ -56,35 +57,35 @@ def test_update_storage(tables):
     util.update_storage()
 
     # Check
+    for host in ["drao", "fir", "scinet"]:
+        StorageHost.get(name=host)
+
     for group in [
         "scinet_staging",
         "scinet_hpss",
         "drao_storage",
-        "cedar_offload",
-        "cedar_online",
-        "cedar_staging",
-        "cedar_nearline",
+        "fir_online",
+        "fir_staging",
+        "fir_nearline",
     ]:
         StorageGroup.get(name=group)
 
     for node in [
         "gong",
-        "cedar_offload",
-        "cedar_staging",
-        "cedar_smallfile",
-        "cedar_nearline",
-        "cedar_online",
+        "fir_staging",
+        "fir_smallfile",
+        "fir_nearline",
+        "fir_online",
         "scinet_staging",
         "scinet_hpss",
     ]:
-        StorageNode.get(name=node)
+        node = StorageNode.get(name=node)
+        assert node.host is not None
 
     edges = [
-        ("gong", "cedar_staging", True, False),
-        ("cedar_staging", "cedar_offload", True, False),
-        ("cedar_staging", "scinet_staging", True, False),
-        ("cedar_staging", "scinet_hpss", False, True),
-        ("cedar_offload", "cedar_nearline", True, True),
+        ("gong", "fir_staging", True, False),
+        ("fir_staging", "fir_nearline", True, True),
+        ("fir_nearline", "scinet_staging", True, False),
         ("scinet_staging", "scinet_hpss", True, True),
     ]
 


### PR DESCRIPTION
See: https://github.com/radiocosmology/alpenhorn/pull/365 and https://github.com/radiocosmology/alpenhorn/pull/369

* Adds the new `StorageHost` table.
* Updates `StorageNode`:
  * remove `address` and `username` (moved to `StorageHost`)
  * change `host` to a foreign key to the `StorageHost` table.
  * replace `storage_type` enum with `archive` boolean.
  * delete obsolete fields `suspect` and `min_delete_age_days`
* Update `util.update_storage`:
  * handle `StorageHost` creation
  * Delete now-unused `cedar_offload` node.
  * Update node names for `fir`